### PR TITLE
Ng model fixes

### DIFF
--- a/ng-pikaday.js
+++ b/ng-pikaday.js
@@ -46,13 +46,10 @@
       require: '?ngModel',
       link: function (scope, elem, attrs, modelCtrl) {
 
-        // Init config Object
+        // Init config Object, onSelect is not scope.$apply is not needed, that is handled by angular automatically
 
-        var config = { field: elem[0], onSelect: function () {
-          setTimeout(function(){
-            scope.$apply();
-          });
-        }};
+        var config = { field: elem[0] };
+        
         var hasMoment = typeof moment === 'function';
         // Decorate config with globals
 
@@ -95,12 +92,7 @@
             case "onDraw":
             case "disableDayFn":
 
-              config[attr] = function (date) {
-                setTimeout(function(){
-                  scope.$apply();
-                });
-                return scope[attr]({ pikaday: this, date: date });
-              };
+              config[attr] = scope[attr];
               break;
 
             // Strings
@@ -164,6 +156,7 @@
               modelCtrl.$setValidity('date', false);
               return modelValue;
             }
+            picker.setDate(date);
             return hasMoment? moment(date).format(picker._o.format) : date.toDateString();
           });
 

--- a/ng-pikaday.js
+++ b/ng-pikaday.js
@@ -163,6 +163,10 @@
           modelCtrl.$parsers.push(function (viewValue) {
             return picker.getDate();
           });
+
+          var pushDateFromPikadayToNgmodel = function() { modelCtrl.$setViewValue(picker.getDate()); };
+          elem[0].addEventListener('blur', pushDateFromPikadayToNgmodel);
+          scope.$on('$destroy', pushDateFromPikadayToNgmodel);
         }
 
         scope.$on('$destroy', function () {

--- a/ng-pikaday.js
+++ b/ng-pikaday.js
@@ -166,7 +166,9 @@
 
           var pushDateFromPikadayToNgmodel = function() { modelCtrl.$setViewValue(picker.getDate()); };
           elem[0].addEventListener('blur', pushDateFromPikadayToNgmodel);
-          scope.$on('$destroy', pushDateFromPikadayToNgmodel);
+          scope.$on('$destroy', function () {
+            elem[0].removeEventListener('blur', pushDateFromPikadayToNgmodel);
+          });
         }
 
         scope.$on('$destroy', function () {


### PR DESCRIPTION
This fixes several bugs: 
 - the initial value of ng-model is not directly set in the pikaday object
 - If you change the value of the input by typing a new date, the ng-model is not directly updated
    (this is because pikaday only updates its value on blur, and at this point the value of the input type=text isn't changed any more, so we need to listen on blur and push the value to the ng-model.